### PR TITLE
Initial support for new Wyze Color Bulbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This plugin adds support for Wyze Connected Home devices to [Homebridge](https:/
 
 ## Supported Devices
 - Light Bulb
+- Color Bulb (Mesh Light)
 - Plug
 - Contact Sensor
 - Motion Sensor

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "colorsys": "^1.0.22",
     "md5": "^2.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-connected-home",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Wyze Connected Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/WyzeAPI.js
+++ b/src/WyzeAPI.js
@@ -21,8 +21,8 @@ module.exports = class WyzeAPI {
     this.authApiKey = options.authApiKey || 'WMXHYf79Nr5gIlt3r0r7p9Tcw5bvs6BB4U8O8nGJ';
     this.phoneId = options.phoneId || 'bc151f39-787b-4871-be27-5a20fd0a1937';
     this.appName = options.appName || 'com.hualai.WyzeCam';
-    this.appVer = options.appVer || 'com.hualai.WyzeCam___2.10.72';
-    this.appVersion = options.appVersion || '2.10.72';
+    this.appVer = options.appVer || 'com.hualai.WyzeCam___2.18.44';
+    this.appVersion = options.appVersion || '2.18.44';
     this.sc = '9f275790cab94a72bd206c8876429f3c';
     this.sv = '9d74946e652647e9b6c9d59326aef104';
 
@@ -225,6 +225,47 @@ module.exports = class WyzeAPI {
     };
 
     const result = await this.request('app/v2/device/set_property', data);
+
+    return result.data;
+  }
+
+  async runActionList(deviceMac, deviceModel, propertyId, propertyValue) {
+    // Wyze Color Bulbs use a new run_action_list endpoint instead of set_property
+    const plist = [
+      {
+        pid: propertyId,
+        pvalue: String(propertyValue),
+      }
+    ];
+    if (propertyId != "P3") {
+      plist.push({
+        pid: "P3",
+        pvalue: "1",
+      })
+    };
+    const innerList = [
+      {
+        mac: deviceMac,
+        plist: plist,
+      }
+    ];
+    const actionParams = {
+      list: innerList,
+    };
+    const actionList = [
+      {
+        instance_id: deviceMac,
+        action_params: actionParams,
+        provider_key: deviceModel,
+        action_key: "set_mesh_property",
+      }
+    ];
+    const data = {
+      action_list: actionList,
+    };
+    this.log.debug(`run_action_list Data Body: ${JSON.stringify(data)}`);
+
+    const result = await this.request('app/v2/auto/run_action_list', data);
 
     return result.data;
   }

--- a/src/WyzeConnectedHome.js
+++ b/src/WyzeConnectedHome.js
@@ -2,6 +2,7 @@ const { homebridge, Accessory, UUIDGen } = require('./types');
 const WyzeAPI = require('./WyzeAPI');
 const WyzePlug = require('./accessories/WyzePlug');
 const WyzeLight = require('./accessories/WyzeLight');
+const WyzeMeshLight = require('./accessories/WyzeMeshLight');
 const WyzeContactSensor = require('./accessories/WyzeContactSensor');
 const WyzeMotionSensor = require('./accessories/WyzeMotionSensor');
 
@@ -118,6 +119,8 @@ module.exports = class WyzeConnectedHome {
         return WyzePlug;
       case 'Light':
         return WyzeLight;
+      case 'MeshLight':
+        return WyzeMeshLight;
       case 'ContactSensor':
         return WyzeContactSensor;
       case 'MotionSensor':

--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -84,4 +84,15 @@ module.exports = class WyzeAccessory {
       this.updating = false;
     }
   }
+  async runActionList(property, value) {
+    try {
+      this.updating = true;
+
+      let response = await this.plugin.client.runActionList(this.mac, this.product_model, property, value);
+
+      this.lastTimestamp = response.ts;
+    } finally {
+      this.updating = false;
+    }
+  }
 };

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -1,0 +1,279 @@
+const { Service, Characteristic } = require('../types');
+const WyzeAccessory = require('./WyzeAccessory');
+
+const WYZE_API_POWER_PROPERTY = 'P3';
+const WYZE_API_BRIGHTNESS_PROPERTY = 'P1501';
+const WYZE_API_COLOR_TEMP_PROPERTY = 'P1502';
+const WYZE_API_COLOR_PROPERTY = 'P1507';
+
+const WYZE_COLOR_TEMP_MIN = 1800;
+const WYZE_COLOR_TEMP_MAX = 6500;
+const HOMEKIT_COLOR_TEMP_MIN = 500;
+const HOMEKIT_COLOR_TEMP_MAX = 140;
+
+module.exports = class WyzeMeshLight extends WyzeAccessory {
+  constructor(plugin, homeKitAccessory) {
+    super(plugin, homeKitAccessory);
+
+    this.getCharacteristic(Characteristic.On).on('set', this.setOn.bind(this));
+    this.getCharacteristic(Characteristic.Brightness).on('set', this.setBrightness.bind(this));
+    this.getCharacteristic(Characteristic.ColorTemperature).on('set', this.setColorTemperature.bind(this));
+    this.getCharacteristic(Characteristic.Hue).on('set', this.setHue.bind(this));
+    this.getCharacteristic(Characteristic.Saturation).on('set', this.setSaturation.bind(this));
+
+    // Local caching of HSL color space handling separate Hue & Saturation on HomeKit
+    // Caching idea for handling HSL colors from:
+    //    https://github.com/QuickSander/homebridge-http-rgb-push/blob/master/index.js
+    this.cache = {};
+    this.cacheUpdated = false;
+  }
+
+  async updateCharacteristics(device) {
+    this.getCharacteristic(Characteristic.On).updateValue(device.device_params.switch_state);
+
+    let propertyList = await this.getPropertyList();
+    for (let property of propertyList.data.property_list) {
+      switch (property.pid) {
+        case WYZE_API_BRIGHTNESS_PROPERTY:
+          this.updateBrightness(property.value);
+          break;
+
+        case WYZE_API_COLOR_TEMP_PROPERTY:
+          this.updateColorTemp(property.value);
+          break;
+
+        case WYZE_API_COLOR_PROPERTY:
+          this.updateColor(property.value);
+          break;
+      }
+    }
+  }
+
+  updateBrightness(value) {
+    this.getCharacteristic(Characteristic.Brightness).updateValue(value);
+  }
+
+  updateColorTemp(value) {
+    let floatValue = this._rangeToFloat(value, WYZE_COLOR_TEMP_MIN, WYZE_COLOR_TEMP_MAX);
+    let homeKitValue = this._floatToRange(floatValue, HOMEKIT_COLOR_TEMP_MIN, HOMEKIT_COLOR_TEMP_MAX);
+    this.getCharacteristic(Characteristic.ColorTemperature).updateValue(homeKitValue);
+  }
+
+  updateColor(value) {
+    // Convert a Hex color from Wyze into the HSL values recognized by HomeKit.
+    let hslValue = this._hexToHSL(value);
+    this.plugin.log.debug(`Updating color record for ${this.homeKitAccessory.context.mac} to ${value}: ${JSON.stringify(hslValue)}`)
+
+    // Update Hue
+    this.updateHue(hslValue.h);
+    this.cache.hue = hslValue.h;
+
+    // Update Saturation
+    this.updateSaturation(hslValue.s);
+    this.cache.saturation = hslValue.s;
+
+    this.cache.brightness = hslValue.l;
+  }
+
+  updateHue(value) {
+    this.getCharacteristic(Characteristic.Hue).updateValue(value);
+  }
+
+  updateSaturation(value) {
+    this.getCharacteristic(Characteristic.Saturation).updateValue(value);
+  }
+
+  getService() {
+    let service = this.homeKitAccessory.getService(Service.Lightbulb);
+
+    if (!service) {
+      service = this.homeKitAccessory.addService(Service.Lightbulb);
+    }
+
+    return service;
+  }
+
+  getCharacteristic(characteristic) {
+    return this.getService().getCharacteristic(characteristic);
+  }
+
+  async setOn(value, callback) {
+    this.plugin.log.info(`Setting power for ${this.homeKitAccessory.context.mac} to ${value}`);
+
+    try {
+      await this.runActionList(WYZE_API_POWER_PROPERTY, (value) ? '1' : '0');
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setBrightness(value, callback) {
+    this.plugin.log.info(`Setting brightness for ${this.homeKitAccessory.context.mac} to ${value}`);
+
+    try {
+      await this.runActionList(WYZE_API_BRIGHTNESS_PROPERTY, value);
+      this.cache.brightness = value;
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setColorTemperature(value, callback) {
+    let floatValue = this._rangeToFloat(value, HOMEKIT_COLOR_TEMP_MIN, HOMEKIT_COLOR_TEMP_MAX);
+    let wyzeValue = this._floatToRange(floatValue, WYZE_COLOR_TEMP_MIN, WYZE_COLOR_TEMP_MAX);
+
+    this.plugin.log.info(`Setting color temperature for ${this.homeKitAccessory.context.mac} to ${value} (${wyzeValue})`);
+
+    try {
+      await this.runActionList(WYZE_API_COLOR_TEMP_PROPERTY, wyzeValue);
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setHue(value, callback) {
+    this.plugin.log.info(`Setting hue (color) for ${this.homeKitAccessory.context.mac} to ${value}`);
+    this.plugin.log.debug(`(H)SL Values: ${value}, ${this.cache.saturation}, ${this.cache.brightness}`);
+
+    try {
+      this.cache.hue = value;
+      if (this.cacheUpdated) {
+        let hexValue = this._HSLToHex(this.cache.hue, this.cache.saturation, this.cache.brightness);
+        hexValue = hexValue.replace("#", "");
+        this.plugin.log.info(hexValue);
+
+        await this.runActionList(WYZE_API_COLOR_PROPERTY, hexValue);
+        this.cacheUpdated = false;
+      } else {
+        this.cacheUpdated = true;
+      }
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setSaturation(value, callback) {
+    this.plugin.log.info(`Setting saturation (color) for ${this.homeKitAccessory.context.mac} to ${value}`);
+    this.plugin.log.debug(`H(S)L Values: ${value}, ${this.cache.saturation}, ${this.cache.brightness}`);
+
+    try {
+      this.cache.saturation = value;
+      if (this.cacheUpdated) {
+        let hexValue = this._HSLToHex(this.cache.hue, this.cache.saturation, this.cache.brightness);
+        hexValue = hexValue.replace("#", "");
+        this.plugin.log.info(hexValue);
+
+        await this.runActionList(WYZE_API_COLOR_PROPERTY, hexValue);
+        this.cacheUpdated = false;
+      } else {
+        this.cacheUpdated = true;
+      }
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  _rangeToFloat(value, min, max) {
+    return (value - min) / (max - min);
+  }
+
+  _floatToRange(value, min, max) {
+    return Math.round((value * (max - min)) + min);
+  }
+
+  _hexToHSL(H) {
+    // Sourced from: https://css-tricks.com/converting-color-spaces-in-javascript/
+    // Convert hex to RGB first
+    let r = 0, g = 0, b = 0;
+    if (H.length == 4) {
+      r = "0x" + H[1] + H[1];
+      g = "0x" + H[2] + H[2];
+      b = "0x" + H[3] + H[3];
+    } else if (H.length == 6) {
+      r = "0x" + H[0] + H[1];
+      g = "0x" + H[2] + H[3];
+      b = "0x" + H[4] + H[5];
+    }
+    // Then to HSL
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    let cmin = Math.min(r,g,b),
+        cmax = Math.max(r,g,b),
+        delta = cmax - cmin,
+        h = 0,
+        s = 0,
+        l = 0;
+  
+    if (delta == 0)
+      h = 0;
+    else if (cmax == r)
+      h = ((g - b) / delta) % 6;
+    else if (cmax == g)
+      h = (b - r) / delta + 2;
+    else
+      h = (r - g) / delta + 4;
+  
+    h = Math.round(h * 60);
+  
+    if (h < 0)
+      h += 360;
+  
+    l = (cmax + cmin) / 2;
+    s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+    s = +(s * 100).toFixed(1);
+    l = +(l * 100).toFixed(1);
+  
+    return {
+      "h": h,
+      "s": s,
+      "l": l,
+    };
+  }
+
+  _HSLToHex(h,s,l) {
+    // Sourced from: https://css-tricks.com/converting-color-spaces-in-javascript/
+    s /= 100;
+    l /= 100;
+  
+    let c = (1 - Math.abs(2 * l - 1)) * s,
+        x = c * (1 - Math.abs((h / 60) % 2 - 1)),
+        m = l - c/2,
+        r = 0,
+        g = 0, 
+        b = 0; 
+  
+    if (0 <= h && h < 60) {
+      r = c; g = x; b = 0;
+    } else if (60 <= h && h < 120) {
+      r = x; g = c; b = 0;
+    } else if (120 <= h && h < 180) {
+      r = 0; g = c; b = x;
+    } else if (180 <= h && h < 240) {
+      r = 0; g = x; b = c;
+    } else if (240 <= h && h < 300) {
+      r = x; g = 0; b = c;
+    } else if (300 <= h && h < 360) {
+      r = c; g = 0; b = x;
+    }
+    // Having obtained RGB, convert channels to hex
+    r = Math.round((r + m) * 255).toString(16);
+    g = Math.round((g + m) * 255).toString(16);
+    b = Math.round((b + m) * 255).toString(16);
+  
+    // Prepend 0s, if necessary
+    if (r.length == 1)
+      r = "0" + r;
+    if (g.length == 1)
+      g = "0" + g;
+    if (b.length == 1)
+      b = "0" + b;
+  
+    return "#" + r + g + b;
+  }
+};

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -1,3 +1,4 @@
+const colorsys = require('colorsys')
 const { Service, Characteristic } = require('../types');
 const WyzeAccessory = require('./WyzeAccessory');
 
@@ -21,8 +22,8 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     this.getCharacteristic(Characteristic.Hue).on('set', this.setHue.bind(this));
     this.getCharacteristic(Characteristic.Saturation).on('set', this.setSaturation.bind(this));
 
-    // Local caching of HSL color space handling separate Hue & Saturation on HomeKit
-    // Caching idea for handling HSL colors from:
+    // Local caching of HSV color space handling separate Hue & Saturation on HomeKit
+    // Caching idea for handling HSV colors from:
     //    https://github.com/QuickSander/homebridge-http-rgb-push/blob/master/index.js
     this.cache = {};
     this.cacheUpdated = false;
@@ -61,7 +62,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
 
   updateColor(value) {
     // Convert a Hex color from Wyze into the HSL values recognized by HomeKit.
-    let hslValue = this._hexToHSL(value);
+    let hslValue = colorsys.hex2Hsv(value);
     this.plugin.log.debug(`Updating color record for ${this.homeKitAccessory.context.mac} to ${value}: ${JSON.stringify(hslValue)}`)
 
     // Update Hue
@@ -71,8 +72,6 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     // Update Saturation
     this.updateSaturation(hslValue.s);
     this.cache.saturation = hslValue.s;
-
-    this.cache.brightness = hslValue.l;
   }
 
   updateHue(value) {
@@ -113,7 +112,6 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
 
     try {
       await this.runActionList(WYZE_API_BRIGHTNESS_PROPERTY, value);
-      this.cache.brightness = value;
       callback();
     } catch (e) {
       callback(e);
@@ -136,12 +134,12 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
 
   async setHue(value, callback) {
     this.plugin.log.info(`Setting hue (color) for ${this.homeKitAccessory.context.mac} to ${value}`);
-    this.plugin.log.debug(`(H)SL Values: ${value}, ${this.cache.saturation}, ${this.cache.brightness}`);
+    this.plugin.log.debug(`(H)S Values: ${value}, ${this.cache.saturation}`);
 
     try {
       this.cache.hue = value;
       if (this.cacheUpdated) {
-        let hexValue = this._HSLToHex(this.cache.hue, this.cache.saturation, this.cache.brightness);
+        let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
         hexValue = hexValue.replace("#", "");
         this.plugin.log.info(hexValue);
 
@@ -158,12 +156,12 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
 
   async setSaturation(value, callback) {
     this.plugin.log.info(`Setting saturation (color) for ${this.homeKitAccessory.context.mac} to ${value}`);
-    this.plugin.log.debug(`H(S)L Values: ${value}, ${this.cache.saturation}, ${this.cache.brightness}`);
+    this.plugin.log.debug(`H(S) Values: ${this.cache.saturation}, ${value}`);
 
     try {
       this.cache.saturation = value;
       if (this.cacheUpdated) {
-        let hexValue = this._HSLToHex(this.cache.hue, this.cache.saturation, this.cache.brightness);
+        let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
         hexValue = hexValue.replace("#", "");
         this.plugin.log.info(hexValue);
 
@@ -184,96 +182,5 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
 
   _floatToRange(value, min, max) {
     return Math.round((value * (max - min)) + min);
-  }
-
-  _hexToHSL(H) {
-    // Sourced from: https://css-tricks.com/converting-color-spaces-in-javascript/
-    // Convert hex to RGB first
-    let r = 0, g = 0, b = 0;
-    if (H.length == 4) {
-      r = "0x" + H[1] + H[1];
-      g = "0x" + H[2] + H[2];
-      b = "0x" + H[3] + H[3];
-    } else if (H.length == 6) {
-      r = "0x" + H[0] + H[1];
-      g = "0x" + H[2] + H[3];
-      b = "0x" + H[4] + H[5];
-    }
-    // Then to HSL
-    r /= 255;
-    g /= 255;
-    b /= 255;
-    let cmin = Math.min(r,g,b),
-        cmax = Math.max(r,g,b),
-        delta = cmax - cmin,
-        h = 0,
-        s = 0,
-        l = 0;
-  
-    if (delta == 0)
-      h = 0;
-    else if (cmax == r)
-      h = ((g - b) / delta) % 6;
-    else if (cmax == g)
-      h = (b - r) / delta + 2;
-    else
-      h = (r - g) / delta + 4;
-  
-    h = Math.round(h * 60);
-  
-    if (h < 0)
-      h += 360;
-  
-    l = (cmax + cmin) / 2;
-    s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
-    s = +(s * 100).toFixed(1);
-    l = +(l * 100).toFixed(1);
-  
-    return {
-      "h": h,
-      "s": s,
-      "l": l,
-    };
-  }
-
-  _HSLToHex(h,s,l) {
-    // Sourced from: https://css-tricks.com/converting-color-spaces-in-javascript/
-    s /= 100;
-    l /= 100;
-  
-    let c = (1 - Math.abs(2 * l - 1)) * s,
-        x = c * (1 - Math.abs((h / 60) % 2 - 1)),
-        m = l - c/2,
-        r = 0,
-        g = 0, 
-        b = 0; 
-  
-    if (0 <= h && h < 60) {
-      r = c; g = x; b = 0;
-    } else if (60 <= h && h < 120) {
-      r = x; g = c; b = 0;
-    } else if (120 <= h && h < 180) {
-      r = 0; g = c; b = x;
-    } else if (180 <= h && h < 240) {
-      r = 0; g = x; b = c;
-    } else if (240 <= h && h < 300) {
-      r = x; g = 0; b = c;
-    } else if (300 <= h && h < 360) {
-      r = c; g = 0; b = x;
-    }
-    // Having obtained RGB, convert channels to hex
-    r = Math.round((r + m) * 255).toString(16);
-    g = Math.round((g + m) * 255).toString(16);
-    b = Math.round((b + m) * 255).toString(16);
-  
-    // Prepend 0s, if necessary
-    if (r.length == 1)
-      r = "0" + r;
-    if (g.length == 1)
-      g = "0" + g;
-    if (b.length == 1)
-      b = "0" + b;
-  
-    return "#" + r + g + b;
   }
 };


### PR DESCRIPTION
This PR adds support for new Wyze Color Bulbs to this Homebridge plug-in.

**A few things of note:**
* The color bulbs seems to use a new API endpoint for updating properties - where all of the other accessories seem to use the `set_property` endpoint, the new color bulbs use a `run_action_list` endpoint.
* In order to support color changing in HomeKit, there is color translation that needs to be done between HSL (used by HomeKit) and Hex values (used by Wyze). I found [these](https://www.ginifab.com/feeds/pms/rgb_to_hsv_hsl.html) [resources](https://www.ginifab.com/feeds/pms/rgb_to_hsv_hsl.html) helpful for understanding HSL and doing [color](https://css-tricks.com/converting-color-spaces-in-javascript/) math.
* One of the biggest challenges is that Hue and Saturation on HomeKit are separate - so when you set the color from HomeKit, Homebridge actually gets 2 calls - 1 for setting Hue and 1 for setting Saturation. I had a hard time figuring out how to handle this the best way, but l luckily I found [another plugin](https://github.com/QuickSander/homebridge-http-rgb-push/blob/master/index.js) which handles this using caching. I implemented this and it seems to work very well so far.
* I am not a Javascript developer at all, so please excuse any sort of Javascript best practices I have broken - happy for any feedback.

I would love others to test this out and see if there is some kind of edge case I overlooked - and even to help contribute any fixes. It doesn't look like this project is very active any more so we will see if we can get this merged or if we need to branch out and create our own.

At the end of the day, the bulb shows up in the Home app and allows me to control all aspects of the bulb:
![image](https://user-images.githubusercontent.com/4342053/113510925-c0bd7300-9522-11eb-8953-27e067d3025e.png)
![image](https://user-images.githubusercontent.com/4342053/113510928-cadf7180-9522-11eb-8887-195f3d362f05.png)
![image](https://user-images.githubusercontent.com/4342053/113510934-d59a0680-9522-11eb-9e5f-4e61e7d740dc.png)
